### PR TITLE
fix: update updateCytoscape call to match new API

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -169,7 +169,14 @@ export default defineComponent({
           graphLog.value.push(JSON.stringify({ agentId, startTime, endTime, nodeId, state, inputs, inputsData, isLoop, result, errorMessage }));
           console.log(log);
           const isServer = serverAgentIds.value.includes(log.agentId || "");
-          updateCytoscape(log.nodeId, log.state === "executing" && isServer ? NodeState.ExecutingServer : log.state);
+          if (isServer && log.state === "executing") {
+            const originalState = log.state;
+            log.state = NodeState.ExecutingServer;
+            updateCytoscape(log);
+            log.state = originalState;
+          } else {
+            updateCytoscape(log);
+          }
         };
         graphResult.value = await graphai.run();
       } catch (e) {


### PR DESCRIPTION
## Summary
- `@receptron/graphai_vue_cytoscape` の `updateCytoscape` API が `(nodeId, state)` の2引数から `(log: TransactionLog)` の1引数に変更されていたため、呼び出しを修正
- CI ビルドエラー (`TS2554: Expected 1 arguments, but got 2`) を解消

## Test plan
- [x] `yarn build` が成功することを確認
- [x] `yarn lint` がエラーなしで通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)