### PR TITLE
fix: add vue type shims for 

### DIFF
--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -1,12 +1,13 @@
 /* eslint-disable */
-declare module '*.vue' {
-  import type { DefineComponent } from 'vue'
-  const component: DefineComponent<{}, {}, any>
-  export default component
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+  const component: DefineComponent<{}, {}, any>;
+  export default component;
 }
-declare module '@vue/runtime-core' {
+declare module "@vue/runtime-core" {
   export interface ComponentCustomProperties {
+    $t: (key: string, ...args: unknown[]) => string;
     localizedUrl: (path: string) => string;
   }
 }
-export {}  // important! see note.
+export {}; // important! see note.


### PR DESCRIPTION
## Summary
- Add shims-vue.d.ts with `$t` type declaration for vue-i18n to fix vue-tsc build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)