### PR TITLE
chore: add OS matrix and node 22/24 to CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure consistent LF line endings across all platforms
+* text=auto eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,24 +4,28 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: write
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [20.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [22.x, 24.x]
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
+        cache: 'yarn'
     - run: yarn install
     - run: yarn run build
     - run: yarn run eslint


### PR DESCRIPTION
## Summary
- Add OS matrix (ubuntu, macos, windows) and Node.js 22/24 to CI workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)